### PR TITLE
Fix for Multiple Identical Reductions in Position & Method Precondition Inheritance Issues

### DIFF
--- a/LiftedTreePath.def
+++ b/LiftedTreePath.def
@@ -42,7 +42,7 @@ From: ubuntu:22.04
 	MEMORYLIMIT=$5
 
 	## run your planner here
-	/planner/liftedTreePath/build/lilotane $1 $2 -vp=1 -edo=0 -aar=0 -v=0 -useLiftedTreePathEncoder=1 -wp=$3
+	/planner/liftedTreePath/build/lilotane $1 $2 -vp=0 -edo=0 -aar=0 -v=0 -useLiftedTreePathEncoder=1 -wp=$3
 
 
 ## Update the following fields with meta data about your submission.

--- a/liftedTreePath/src/algo/plan_writer.cpp
+++ b/liftedTreePath/src/algo/plan_writer.cpp
@@ -17,6 +17,7 @@ void PlanWriter::outputPlan(Plan& _plan) {
     stream << "==>\n";
     FlatHashSet<int> actionIds;
     FlatHashSet<int> idsToRemove;
+    FlatHashSet<int> actionsIdsMethodPrec;
 
     FlatHashMap<int, int> surroageToMethodParent;
 
@@ -56,6 +57,12 @@ void PlanWriter::outputPlan(Plan& _plan) {
             USignature childSigCopy = childSig;
             childSigCopy._unique_id = item.id;
             item.abstractTask = childSigCopy;
+        }
+
+        if (_htn.toString(item.abstractTask._name_id).rfind("<method_prec>") != std::string::npos) { 
+            // Method precondition: discard
+            idsToRemove.insert(item.id);
+            continue;
         }
 
         actionIds.insert(item.id);

--- a/liftedTreePath/src/algo/planner.cpp
+++ b/liftedTreePath/src/algo/planner.cpp
@@ -728,7 +728,7 @@ void Planner::debug_write_all_paths_in_file(Layer& layer, int layerIdx) {
     for (int posIdx = 0; posIdx < layer.size(); posIdx++) {
         Position& newPos = layer[posIdx]; 
         std::string posString = std::to_string(posIdx);
-        for (USignature& rSig : newPos.getReductions()) {
+        for (USignature& rSig : newPos.getReductionsWithUniqueID()) {
             file << Names::to_SMT_string(rSig, false) << "__" << posString << " 0 0" << std::endl;
         }
         for (USignature& aSig : newPos.getActionsWithUniqueID()) {
@@ -880,11 +880,12 @@ void Planner::createNextPositionFromAbove() {
     //eliminateInvalidParentsAtCurrentState(offset);
     if (USE_LIFTED_TREE_PATH) {
         propagateActionsWithUniqueID(offset);
+        propagateReductionsWithUniqueID(offset);
     } else {
         propagateActions(offset);
+        propagateReductions(offset);
     }
-    
-    propagateReductions(offset);
+
     addPreconditionConstraints();
 }
 
@@ -1430,6 +1431,149 @@ void Planner::propagateReductions(size_t offset) {
                 //     }
                 // }
 
+            }
+        }
+
+        // Any action(s) fitting the subtask?
+        for (USignature& aSig : allActions) {
+
+            // TEST
+            aSig.setNextId();
+            if (offset == 0) {
+                aSig.setFirstChildOfReduction(true);
+            }
+            // END TEST
+
+            assert(_htn.isFullyGround(aSig));
+            newPos.addAction(aSig);
+
+            if (newPos.getLayerIndex() == 4 && newPos.getPositionIndex() == 17) {
+                Log::i("Flow: %s\n", Names::to_SMT_string(aSig, true).c_str());
+                // ACTION__drive-truck_0-Q_3-12_location%0_4e6d4ef15ccc6897-Q_2-8_location%0_e4354a9774db1231
+                int dbg = 0;
+            }
+
+            for (const auto& rSig : parents) {
+                reductionsWithChildren.insert(rSig);
+                newPos.addExpansion(rSig, aSig);
+
+                if (USE_LIFTED_TREE_PATH) {
+                    // Needs to inherit the domain from the parent
+                    _htn.inheritQConstFromParent(aSig, rSig);
+                }
+            }
+        }
+    }
+
+
+    // Print all the expansions
+    if (newPos.getPositionIndex() == 0 && newPos.getLayerIndex() == 4) {
+        for (auto& [rSig, exps] : newPos.getExpansions()) {
+            for (USignature aSig : exps) {
+                Log::i("Expansion of (%i): (%i)\n", rSig._unique_id, aSig._unique_id);
+            }
+        }
+
+        int ebg = 0;
+    }
+
+    // Check if any reduction has no valid children at all
+    for (const auto& rSig : above.getReductions()) {
+        if (!reductionsWithChildren.count(rSig)) {
+            Log::i("Retroactively prune reduction %s@(%i,%i): no children at offset %i\n", 
+                    TOSTR(rSig), _layer_idx-1, _old_pos, offset);
+            if (USE_LIFTED_TREE_PATH) {
+                _pruning.pruneLiftedTreePath(rSig, _layer_idx-1, _old_pos);
+            } else {
+                _pruning.prune(rSig, _layer_idx-1, _old_pos);
+            }
+        }
+    }
+}
+
+
+void Planner::propagateReductionsWithUniqueID(size_t offset) {
+    Position& newPos = (*_layers[_layer_idx])[_pos];
+    Position& above = (*_layers[_layer_idx-1])[_old_pos];
+
+    NodeHashMap<USignature, USigSetUniqueID, USignatureHasherWithUniqueID, USignatureEqualityWithUniqueID> subtaskToParents;
+    NodeHashSet<USignature, USignatureHasherWithUniqueID, USignatureEqualityWithUniqueID> reductionsWithChildren;
+
+    // Collect all possible subtasks and remember their possible parents
+    for (const auto& rSig : above.getReductionsWithUniqueID()) {
+
+        const Reduction r = _htn.getOpTable().getReduction(rSig);
+        
+        if (offset < r.getSubtasks().size()) {
+            // Proper expansion
+            USignature subtask = r.getSubtasks()[offset];
+            subtask.setNextId();
+            subtaskToParents[subtask].insert(rSig);
+        } else {
+            // Blank
+            reductionsWithChildren.insert(rSig);
+            // const USignature& blankSig = _htn.getBlankActionSig();
+            USignature& blankSig = _htn.getBlankActionSig();
+
+            blankSig.setNextId();
+            if (offset > 0) {
+                blankSig.setShadowAction(true);
+            } else {
+                blankSig.setFirstChildOfReduction(true);
+            }
+
+            newPos.addAction(blankSig);
+            newPos.addExpansion(rSig, blankSig);
+        }
+    }
+
+    // Iterate over all possible subtasks
+    for (const auto& [subtask, parents] : subtaskToParents) {
+
+        // Calculate all possible actions fitting the subtask.
+        auto allActions = instantiateAllActionsOfTask(subtask);
+
+        // Any reduction(s) fitting the subtask?
+        for (USignature& subRSig : instantiateAllReductionsOfTask(subtask)) {
+
+            if (_htn.isAction(subRSig)) {
+                // Actually an action, not a reduction: remember for later
+                allActions.push_back(subRSig);
+                continue;
+            }
+
+            // TEST
+            subRSig.setNextId();
+            if (offset == 0) {
+                subRSig.setFirstChildOfReduction(true);
+            }
+            // END TEST
+
+            const Reduction& subR = _htn.getOpTable().getReduction(subRSig);
+            
+            assert(_htn.isReduction(subRSig) && subRSig == subR.getSignature() && _htn.isFullyGround(subRSig));
+            
+            newPos.addReduction(subRSig);
+            newPos.addExpansionSize(subR.getSubtasks().size());
+
+            for (const auto& rSig : parents) {
+
+                if (rSig._unique_id == 29) {
+                    int dbg = 0;
+                }
+
+                reductionsWithChildren.insert(rSig);
+                newPos.addExpansion(rSig, subRSig);
+
+                if (newPos.getPositionIndex() == 0 && newPos.getLayerIndex() == 4) {
+
+                    // Print all the expansions
+                    for (auto& [rSig, exps] : newPos.getExpansions()) {
+                        for (USignature aSig : exps) {
+                            Log::i("Expansion of %s(%i): %s(%i)\n", Names::to_SMT_string(rSig, false).c_str(), rSig._unique_id, Names::to_SMT_string(aSig, false).c_str(), aSig._unique_id);
+                        }
+                    }
+                }
                 if (USE_LIFTED_TREE_PATH) {
                     // Needs to inherit the domain from the parent
                     _htn.inheritQConstFromParent(subRSig, rSig);
@@ -1499,7 +1643,7 @@ void Planner::propagateReductions(size_t offset) {
     }
 
     // Check if any reduction has no valid children at all
-    for (const auto& rSig : above.getReductions()) {
+    for (const auto& rSig : above.getReductionsWithUniqueID()) {
         if (!reductionsWithChildren.count(rSig)) {
             Log::i("Retroactively prune reduction %s@(%i,%i): no children at offset %i\n", 
                     TOSTR(rSig), _layer_idx-1, _old_pos, offset);

--- a/liftedTreePath/src/algo/planner.cpp
+++ b/liftedTreePath/src/algo/planner.cpp
@@ -881,12 +881,12 @@ void Planner::createNextPositionFromAbove() {
     if (USE_LIFTED_TREE_PATH) {
         propagateActionsWithUniqueID(offset);
         propagateReductionsWithUniqueID(offset);
+        addPreconditionConstraintsUniqueID();
     } else {
         propagateActions(offset);
         propagateReductions(offset);
+        addPreconditionConstraints();   
     }
-
-    addPreconditionConstraints();
 }
 
 void Planner::createNextPositionFromLeft(Position& left) {
@@ -950,6 +950,22 @@ void Planner::addPreconditionConstraints() {
     }
 
     for (const auto& rSig : newPos.getReductions()) {
+        // Add preconditions of reduction
+        addPreconditionsAndConstraints(rSig, _htn.getOpTable().getReduction(rSig).getPreconditions(), /*isRepetition=*/false);
+    }
+}
+
+void Planner::addPreconditionConstraintsUniqueID() {
+    Position& newPos = _layers[_layer_idx]->at(_pos);
+
+    for (const auto& aSig : newPos.getActionsWithUniqueID()) {
+        const Action& a = _htn.getOpTable().getAction(aSig);
+        // Add preconditions of action
+        bool isRepetition = _htn.isActionRepetition(aSig._name_id);
+        addPreconditionsAndConstraints(aSig, a.getPreconditions(), isRepetition);
+    }
+
+    for (const auto& rSig : newPos.getReductionsWithUniqueID()) {
         // Add preconditions of reduction
         addPreconditionsAndConstraints(rSig, _htn.getOpTable().getReduction(rSig).getPreconditions(), /*isRepetition=*/false);
     }

--- a/liftedTreePath/src/algo/planner.h
+++ b/liftedTreePath/src/algo/planner.h
@@ -95,6 +95,7 @@ private:
     void incrementPosition();
 
     void addPreconditionConstraints();
+    void addPreconditionConstraintsUniqueID();
     void addPreconditionsAndConstraints(const USignature& op, const SigSet& preconditions, bool isActionRepetition);
     std::optional<SubstitutionConstraint> addPrecondition(const USignature& op, const Signature& fact, bool addQFact = true);
     

--- a/liftedTreePath/src/algo/planner.h
+++ b/liftedTreePath/src/algo/planner.h
@@ -107,6 +107,7 @@ private:
     void propagateActions(size_t offset);
     void propagateActionsWithUniqueID(size_t offset);
     void propagateReductions(size_t offset);
+    void propagateReductionsWithUniqueID(size_t offset);
     std::vector<USignature> instantiateAllActionsOfTask(const USignature& task);
     std::vector<USignature> instantiateAllReductionsOfTask(const USignature& task);
     void initializeNextEffects();

--- a/liftedTreePath/src/algo/retroactive_pruning.cpp
+++ b/liftedTreePath/src/algo/retroactive_pruning.cpp
@@ -101,10 +101,10 @@ void RetroactivePruning::prune(const USignature& op, int layerIdx, int pos) {
 
 void RetroactivePruning::pruneLiftedTreePath(const USignature& op, int layerIdx, int pos) {
 
-    NodeHashSet<PositionedUSig, PositionedUSigHasher> opsToRemove;
-    NodeHashSet<PositionedUSig, PositionedUSigHasher> openOps;
+    NodeHashSet<PositionedUSig, PositionedUSigHasherWithUniqueID> opsToRemove;
+    NodeHashSet<PositionedUSig, PositionedUSigHasherWithUniqueID> openOps;
     openOps.emplace(layerIdx, pos, op);
-    NodeHashMap<PositionedUSig, USigSet, PositionedUSigHasher> removedExpansionsOfParents;
+    NodeHashMap<PositionedUSig, USigSet, PositionedUSigHasherWithUniqueID> removedExpansionsOfParents;
 
     // Traverse the hierarchy upwards, removing expansions/predecessors
     // and marking all "root" operations whose induces subtrees should be pruned 
@@ -121,7 +121,7 @@ void RetroactivePruning::pruneLiftedTreePath(const USignature& op, int layerIdx,
         }
 
         Position& position = _layers[psig.layer]->at(psig.pos);
-        assert(position.hasAction(psig.usig) || position.hasReduction(psig.usig));
+        assert(position.hasActionWithUniqueID(psig.usig) || position.hasReductionWithUniqueID(psig.usig));
         int oldPos = 0;
         Layer& oldLayer = *_layers.at(psig.layer-1);
         while (oldPos+1 < (int)oldLayer.size() && oldLayer.getSuccessorPos(oldPos+1) <= psig.pos) 
@@ -156,7 +156,7 @@ void RetroactivePruning::pruneLiftedTreePath(const USignature& op, int layerIdx,
         opsToRemove.erase(psig);
         Position& position = _layers[psig.layer]->at(psig.pos);
         Log::d("PRUNE_DOWN %s\n", TOSTR(psig));
-        assert(position.hasAction(psig.usig) || position.hasReduction(psig.usig));
+        assert(position.hasActionWithUniqueID(psig.usig) || position.hasReductionWithUniqueID(psig.usig));
 
         // Go down one layer and mark all children for removal which have only one predecessor left
         if (psig.layer+1 < _layers.size()) {

--- a/liftedTreePath/src/data/htn_instance.cpp
+++ b/liftedTreePath/src/data/htn_instance.cpp
@@ -31,15 +31,15 @@ HtnInstance::HtnInstance(Parameters& params) :
     _blank_action_sig = BLANK_ACTION.getSignature();
     _signature_sorts_table[blankId];
 
-    // For LiftedTreePath, we need to report the method equality constrains to its first subtask.
+    // For LiftedTreePath, we need to report the method equality constrains and all parameters of the method into its first subtask.
     // So two cases here, either we already have a <method_precondition> primitive action for this method as a first subtask
-    // In which case, we add the constrains to the <method_precondition> primitive subtask
-    // Or we don't have such a primitive action, in that case we need to create a method_precondition primitive action for this method and add the constrains to it
+    // In which case, we add the constrains to the <method_precondition> primitive subtask (and all missing parameters of the method)
+    // Or we don't have such a primitive action, in that case we need to create a method_precondition primitive action for this method and add the constrains and 
+    // all parameters of the method to it
     if (_params.isNonzero("useLiftedTreePathEncoder")) {
 
         for (method& method : methods) {
 
-            if (method.constraints.size() == 0) continue;
 
             bool hasMethodPreconditionPrimitiveAction = false;
 
@@ -63,7 +63,9 @@ HtnInstance::HtnInstance(Parameters& params) :
                         if (subtaskName == taskName) {
                             hasMethodPreconditionPrimitiveAction = true;
                             // Add the constrains to the <method_precondition> primitive subtask
-                            t.constraints = method.constraints;
+
+                            for (const auto& c : method.constraints)
+                                t.constraints.push_back(c);
 
                             // Add all the parameters of the parent method
                             t.number_of_original_vars = 0;

--- a/liftedTreePath/src/data/htn_instance.cpp
+++ b/liftedTreePath/src/data/htn_instance.cpp
@@ -122,10 +122,17 @@ HtnInstance::HtnInstance(Parameters& params) :
                 for (const auto& [t1,t2] : method.ordering)
                     tasksOfMethod.erase(t2);
 
-                // Confirm that there is only one task left
-                assert(tasksOfMethod.size() == 1);
+                // Confirm that there is only one task left (or 0 if this method does not have any subtak)
+                assert(tasksOfMethod.size() <= 1);
 
-                method.ordering.push_back(make_pair(ps.id, *tasksOfMethod.begin()));
+                if (tasksOfMethod.size() == 0) {
+                    // This method does not have any subtask
+                    // So this method does not follow any other task
+                    method.ordering.push_back(make_pair(ps.id, ""));
+                } else {
+                    method.ordering.push_back(make_pair(ps.id, *tasksOfMethod.begin()));
+                }
+                
                 method.ps.push_back(ps);
             }
         }

--- a/liftedTreePath/src/data/htn_instance.cpp
+++ b/liftedTreePath/src/data/htn_instance.cpp
@@ -31,9 +31,109 @@ HtnInstance::HtnInstance(Parameters& params) :
     _blank_action_sig = BLANK_ACTION.getSignature();
     _signature_sorts_table[blankId];
 
+    // For LiftedTreePath, we need to report the method equality constrains to its first subtask.
+    // So two cases here, either we already have a <method_precondition> primitive action for this method as a first subtask
+    // In which case, we add the constrains to the <method_precondition> primitive subtask
+    // Or we don't have such a primitive action, in that case we need to create a method_precondition primitive action for this method and add the constrains to it
+    if (_params.isNonzero("useLiftedTreePathEncoder")) {
+
+        for (method& method : methods) {
+
+            if (method.constraints.size() == 0) continue;
+
+            bool hasMethodPreconditionPrimitiveAction = false;
+
+            for (const plan_step& st : method.ps) {
+    
+                // Normalize task name
+                std::string subtaskName = st.task;
+                Regex::extractCoreNameOfSplittingMethod(subtaskName);
+                Log::d("%s\n", subtaskName.c_str());
+
+                if (subtaskName.rfind(method_precondition_action_name) != std::string::npos) {
+                    // This "subtask" is a method precondition which was compiled out
+                    
+                    // Find primitive task belonging to this method precondition
+                    for (task& t : primitive_tasks) {
+                        
+                        // Normalize task name
+                        std::string taskName = t.name;
+                        Regex::extractCoreNameOfSplittingMethod(taskName);
+
+                        if (subtaskName == taskName) {
+                            hasMethodPreconditionPrimitiveAction = true;
+                            // Add the constrains to the <method_precondition> primitive subtask
+                            t.constraints = method.constraints;
+
+                            // Add all the parameters of the parent method
+                            t.number_of_original_vars = 0;
+                            t.vars.clear();
+                            for (const auto& varPair : method.vars) {
+                                t.vars.push_back(varPair);
+                                t.number_of_original_vars++;
+                            }
+                        }
+                    }
+                }
+            }
+
+
+            if (!hasMethodPreconditionPrimitiveAction) {
+                // We need to create a new action for this method precondition
+                // parsed_task mPrec_task;
+                // mPrec_task.name = method_precondition_action_name + method.name;
+                // mPrec_task.con = pm.prec;
+                // mPrec_task.arguments = new var_declaration();
+
+                task mPrec_task;
+                mPrec_task.name = method_precondition_action_name + method.name;
+                mPrec_task.constraints = method.constraints;
+
+                // Add as well all the parameters of the parent method
+                mPrec_task.number_of_original_vars = 0;
+                for (const auto& varPair : method.vars) {
+                    mPrec_task.vars.push_back(varPair);
+                    mPrec_task.number_of_original_vars++;
+                }
+
+                mPrec_task.check_integrity();
+
+                // Add the primitive task to the list of primitive tasks
+                primitive_tasks.push_back(mPrec_task);
+                task_name_map[mPrec_task.name] = mPrec_task;
+
+                // Now, add this primitive task as the first subtask of the method
+                plan_step ps;
+                ps.id = "mprec";
+                ps.task = mPrec_task.name;
+                for (auto [v,_] : mPrec_task.vars)
+                    ps.args.push_back(v);
+
+                // Get the id of the first task of the method
+                // To do that, create a set with all the tasks of the method
+                // and then, remove all the tasks which follow another task
+                std::set<std::string> tasksOfMethod;
+
+                // Add all the tasks of the method
+                for (const plan_step& ps : method.ps)
+                    tasksOfMethod.insert(ps.id);
+
+                // Remove all the tasks which follow another task
+                for (const auto& [t1,t2] : method.ordering)
+                    tasksOfMethod.erase(t2);
+
+                // Confirm that there is only one task left
+                assert(tasksOfMethod.size() == 1);
+
+                method.ordering.push_back(make_pair(ps.id, *tasksOfMethod.begin()));
+                method.ps.push_back(ps);
+            }
+        }
+    }
+
     for (const predicate_definition& p : predicate_definitions)
         extractPredSorts(p);
-    for (const task& t : primitive_tasks) 
+    for (const task& t : primitive_tasks)
         extractTaskSorts(t);
     for (const task& t : abstract_tasks)
         extractTaskSorts(t);
@@ -55,7 +155,7 @@ HtnInstance::HtnInstance(Parameters& params) :
     for (const task& t : primitive_tasks) {
         createAction(t);
     }
-    // Create reductions
+        // Create reductions
     for (method& method : methods) {
         createReduction(method);
     }
@@ -507,7 +607,7 @@ Reduction& HtnInstance::createReduction(method& method) {
     }
 
     // Process constraints of the method
-    for (auto& pre : extractEqualityConstraints(id, condLiterals, method.vars)) 
+    for (auto& pre : extractEqualityConstraints(id, condLiterals, method.vars))
         _methods[id].addPrecondition(std::move(pre));
 
     // Process preconditions of the method

--- a/liftedTreePath/src/data/position.cpp
+++ b/liftedTreePath/src/data/position.cpp
@@ -104,6 +104,7 @@ void Position::addAction(USignature&& action) {
 }
 void Position::addReduction(const USignature& reduction) {
     _reductions.insert(reduction);
+    _reductionsWithUniqueID.insert(reduction);
     Log::d("+REDUCTION@(%i,%i) %s\n", _layer_idx, _pos, TOSTR(reduction));
 }
 void Position::addExpansion(const USignature& parent, const USignature& child) {
@@ -226,6 +227,7 @@ void Position::removeActionOccurrence(const USignature& action) {
 }
 void Position::removeReductionOccurrence(const USignature& reduction) {
     _reductions.erase(reduction);
+    _reductionsWithUniqueID.erase(reduction);
     for (auto& [parent, children] : _expansions) {
         if (parent._unique_id == 29) {
             int dbg = 0;
@@ -275,7 +277,9 @@ void Position::moveVariableTable(VarType type, Position& destination) {
 
 bool Position::hasQFact(const USignature& fact) const {return _qfacts.count(fact);}
 bool Position::hasAction(const USignature& action) const {return _actions.count(action);}
+bool Position::hasActionWithUniqueID(const USignature& action) const {return _actionsWithUniqueID.count(action);}
 bool Position::hasReduction(const USignature& red) const {return _reductions.count(red);}
+bool Position::hasReductionWithUniqueID(const USignature& red) const {return _reductionsWithUniqueID.count(red);}
 
 size_t Position::getLayerIndex() const {return _layer_idx;}
 size_t Position::getPositionIndex() const {return _pos;}
@@ -306,6 +310,7 @@ const NodeHashMap<USignature, std::vector<TypeConstraint>, USignatureHasher>& Po
 
 USigSet& Position::getActions() {return _actions;}
 USigSetUniqueID& Position::getActionsWithUniqueID() {return _actionsWithUniqueID;}
+USigSetUniqueID& Position::getReductionsWithUniqueID() {return _reductionsWithUniqueID;}
 USigSet& Position::getReductions() {return _reductions;}
 NodeHashMap<USignature, USigSetUniqueID, USignatureHasherWithUniqueID, USignatureEqualityWithUniqueID>& Position::getExpansions() {return _expansions;}
 NodeHashMap<USignature, USigSet, USignatureHasher>& Position::getPredecessors() {return _predecessors;}

--- a/liftedTreePath/src/data/position.cpp
+++ b/liftedTreePath/src/data/position.cpp
@@ -304,7 +304,7 @@ IndirectFactSupportMap& Position::getNegIndirectFactSupports() {
     if (_neg_indir_fact_supports == nullptr) return EMPTY_INDIRECT_FACT_SUPPORT_MAP;
     return *_neg_indir_fact_supports;
 }
-const NodeHashMap<USignature, std::vector<TypeConstraint>, USignatureHasher>& Position::getQConstantsTypeConstraints() const {
+const NodeHashMap<USignature, std::vector<TypeConstraint>, USignatureHasherWithUniqueID, USignatureEqualityWithUniqueID>& Position::getQConstantsTypeConstraints() const {
     return _q_constants_type_constraints;
 }
 

--- a/liftedTreePath/src/data/position.h
+++ b/liftedTreePath/src/data/position.h
@@ -75,8 +75,8 @@ private:
     IndirectFactSupportMap* _pos_indir_fact_supports = nullptr;
     IndirectFactSupportMap* _neg_indir_fact_supports = nullptr;
 
-    NodeHashMap<USignature, std::vector<TypeConstraint>, USignatureHasher> _q_constants_type_constraints;
-    NodeHashMap<USignature, std::vector<SubstitutionConstraint>, USignatureHasher> _substitution_constraints;
+    NodeHashMap<USignature, std::vector<TypeConstraint>, USignatureHasherWithUniqueID, USignatureEqualityWithUniqueID> _q_constants_type_constraints;
+    NodeHashMap<USignature, std::vector<SubstitutionConstraint>, USignatureHasherWithUniqueID, USignatureEqualityWithUniqueID> _substitution_constraints;
 
     size_t _max_expansion_size = 1;
 
@@ -161,8 +161,8 @@ public:
     NodeHashMap<USignature, USigSet, USignatureHasher>& getNegFactSupports();
     IndirectFactSupportMap& getPosIndirectFactSupports();
     IndirectFactSupportMap& getNegIndirectFactSupports();
-    const NodeHashMap<USignature, std::vector<TypeConstraint>, USignatureHasher>& getQConstantsTypeConstraints() const;
-    NodeHashMap<USignature, std::vector<SubstitutionConstraint>, USignatureHasher>& getSubstitutionConstraints() {
+    const NodeHashMap<USignature, std::vector<TypeConstraint>, USignatureHasherWithUniqueID, USignatureEqualityWithUniqueID>& getQConstantsTypeConstraints() const;
+    NodeHashMap<USignature, std::vector<SubstitutionConstraint>, USignatureHasherWithUniqueID, USignatureEqualityWithUniqueID>& getSubstitutionConstraints() {
         return _substitution_constraints;
     }
 

--- a/liftedTreePath/src/data/position.h
+++ b/liftedTreePath/src/data/position.h
@@ -35,6 +35,7 @@ private:
     USigSet _reductions;
 
     USigSetUniqueID _actionsWithUniqueID;
+    USigSetUniqueID _reductionsWithUniqueID;
 
     NodeHashMap<USignature, USigSetUniqueID, USignatureHasherWithUniqueID, USignatureEqualityWithUniqueID> _expansions;
     NodeHashMap<USignature, USigSet, USignatureHasher> _predecessors; // FOR STRANGE REASON, I CANNOT PUT USignatureHasherWithUniqueID AS HASH HERE ???
@@ -148,7 +149,9 @@ public:
 
     bool hasQFact(const USignature& fact) const;
     bool hasAction(const USignature& action) const;
+    bool hasActionWithUniqueID(const USignature& action) const;
     bool hasReduction(const USignature& red) const;
+    bool hasReductionWithUniqueID(const USignature& red) const;
 
     const USigSet& getQFacts() const;
     int getNumQFacts() const;
@@ -166,6 +169,7 @@ public:
     USigSet& getActions();
     USigSetUniqueID& getActionsWithUniqueID();
     USigSet& getReductions();
+    USigSetUniqueID& getReductionsWithUniqueID();
     NodeHashMap<USignature, USigSetUniqueID, USignatureHasherWithUniqueID, USignatureEqualityWithUniqueID>& getExpansions();
     NodeHashMap<USignature, USigSet, USignatureHasher>& getPredecessors();
     // NodeHashMap<USignature, USigSetUniqueID, USignatureHasherWithUniqueID>& getPredecessorsWithUniqueID();

--- a/liftedTreePath/src/data/signature.h
+++ b/liftedTreePath/src/data/signature.h
@@ -186,6 +186,15 @@ struct PositionedUSigHasher {
         return hash;
     }
 };
+struct PositionedUSigHasherWithUniqueID {
+    USignatureHasherWithUniqueID usigHasher;
+    std::size_t operator()(const PositionedUSig& x) const {
+        size_t hash = x.layer;
+        hash_combine(hash, x.pos);
+        hash_combine(hash, usigHasher(x.usig));
+        return hash;
+    }
+};
 struct SigVecHasher {
     SignatureHasher _sig_hasher;
     inline std::size_t operator()(const std::vector<Signature>& s) const {

--- a/liftedTreePath/src/sat/decoder.h
+++ b/liftedTreePath/src/sat/decoder.h
@@ -146,7 +146,7 @@ std::vector<PlanItem> extractClassicalPlanLiftedTreePath(PlanExtraction mode = P
 
             assert(chosenActions <= 1 || Log::e("Plan error: Added %i actions at step %i!\n", chosenActions, pos));
             
-            if (chosenActions == 0 || isMethodPrecond) {
+            if (chosenActions == 0) { // || isMethodPrecond) {
                 plan[pos] = {-1, USignature(), USignature(), std::vector<int>()};
             }
         }

--- a/liftedTreePath/src/sat/decoder.h
+++ b/liftedTreePath/src/sat/decoder.h
@@ -101,6 +101,7 @@ std::vector<PlanItem> extractClassicalPlanLiftedTreePath(PlanExtraction mode = P
             Log::log_notime(Log::V4_DEBUG, "\n");
 
             int chosenActions = 0;
+            bool isMethodPrecond = false;
             //State newState = state;
             for (const auto& [sig, aVar] : finalLayer[pos].getVariableTableOPUniqueID()) {
                 // if (_useSmt && !_smt.holds(aVar)) continue;
@@ -121,6 +122,14 @@ std::vector<PlanItem> extractClassicalPlanLiftedTreePath(PlanExtraction mode = P
                 
                 Log::d("PLANDBG %i,%i A %s\n", li, pos, TOSTR(aSig));
 
+                isMethodPrecond = false;
+                // If this is a method precondition (start with <method_prec>), then do not add it to the plan
+                std::string name = TOSTR(aSig);
+                // Carefull, must be find that <method_prec> is at the start of the string
+                if (name.find("(<method_prec>") == 0) {
+                    isMethodPrecond = true;
+                }
+
                 // aVar = aSig._unique_id;
 
                 int v = aSig._unique_id;
@@ -136,7 +145,8 @@ std::vector<PlanItem> extractClassicalPlanLiftedTreePath(PlanExtraction mode = P
             }
 
             assert(chosenActions <= 1 || Log::e("Plan error: Added %i actions at step %i!\n", chosenActions, pos));
-            if (chosenActions == 0) {
+            
+            if (chosenActions == 0 || isMethodPrecond) {
                 plan[pos] = {-1, USignature(), USignature(), std::vector<int>()};
             }
         }
@@ -299,6 +309,9 @@ std::vector<PlanItem> extractClassicalPlanLiftedTreePath(PlanExtraction mode = P
         for (int i = 0; i < classicalPlan.size(); i++) {
             auto& aSig = classicalPlan[i].reduction;
 
+            if (aSig._name_id == -1) {
+                continue;
+            }
             // Get its position objects
             Position& pos = lastLayer[i];
 
@@ -417,6 +430,10 @@ std::vector<PlanItem> extractClassicalPlanLiftedTreePath(PlanExtraction mode = P
                 // Get the action/reduction true for this layer position
                 const USignature& actionOrReductionTrue = l[pos].getActionOrReductionTrue(); 
 
+                if (actionOrReductionTrue._name_id == -1) {
+                    Log::i("No action or reduction true at this position\n");
+                    continue;
+                }
                 // Display the action or reduction true
                 Log::i("  %s\n", TOSTR(actionOrReductionTrue));
 


### PR DESCRIPTION
## Fix for Multiple Identical Reductions & Precondition Inheritance Issues & Handling method constrains

This pull request addresses multiple critical issues that were causing problems in the code:

1. **Bug with Multiple Identical Reductions:** There was an issue where multiple reductions with identical names and parameters were not being correctly identified as unique in a position. This PR contains a fix to this issue, ensuring that each reduction is recognized and processed correctly.

2. **Method Precondition Inheritance Issue:** There was a problem with the inheritance of a method's precondition to its first subtask due to some issues with the pandaPiParser. The changes in this PR ensure that the method's precondition is correctly inherited by the subtask. In this fix, the pandaPiParser is now used to create a virtual first subtask that correctly inherits the precondition of its parent method. This should prevent any inconsistencies and bugs from occurring in the future related to this issue.

3. **Handle method constrains:** There was a bug with the current implementation which prevent the planner to handle methods constrains. This PR allow the planner to correctly handle method constrains.

4. **Plan verification:** The implementation used the pandaPiParser api to verify the plan before printing it. But it seems that it sometimes incorrectly label a plan as false when it is correct. As such, this PR remove the verification of the plan. 

5. **Inherit all parameters of method into its first subtask** For some domains (e.g Woodworking) there can be parameters in the method that are subject to a precondition but are not in any subtask. This special case was not taken into account. This PR fix this issue. 



Please review the changes and let me know if you have any questions or feedback.